### PR TITLE
[일반야구 lv1] 나머지 테스트 조건 구현, 게임 초기화 기능 추가

### DIFF
--- a/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/model/GameEntity.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/model/GameEntity.java
@@ -1,0 +1,15 @@
+package com.hyunec.cosmicbaseballinit.domain.baseball.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class GameEntity {
+
+    private String message;
+}

--- a/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/repository/PlateAppearances.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/repository/PlateAppearances.java
@@ -38,6 +38,17 @@ public class PlateAppearances {
         return BattingResult.of(battings.get(battings.size() - 1));
     }
 
+    public boolean notYetStarted() {
+        return battings.isEmpty();
+    }
+
+    public boolean isFinished() {
+        if (notYetStarted()) {
+            return false;
+        }
+        return result() == BattingResult.HIT || result() == BattingResult.OUT || result() == BattingResult.FOUR_BALL;
+    }
+
     public void clear() {
         battings.clear();
     }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/service/GameService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/service/GameService.java
@@ -2,6 +2,7 @@ package com.hyunec.cosmicbaseballinit.domain.baseball.service;
 
 import com.hyunec.cosmicbaseballinit.domain.baseball.model.Batting;
 import com.hyunec.cosmicbaseballinit.domain.baseball.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.domain.baseball.model.GameEntity;
 import com.hyunec.cosmicbaseballinit.domain.baseball.repository.PlateAppearances;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,5 +19,17 @@ public class GameService {
         plateAppearances.batting(Batting.generate());
         log.info("### plateAppearances.result()={}", plateAppearances.result());
         return plateAppearances.result();
+    }
+
+    public GameEntity initGame() {
+        if (plateAppearances.isFinished()) {
+            plateAppearances.clear();
+            return GameEntity.builder()
+                .message("새로운 게임이 생성되었습니다.")
+                .build();
+        }
+        return GameEntity.builder()
+            .message("아직 게임이 끝나지 않았습니다.")
+            .build();
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/web/GameController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/domain/baseball/web/GameController.java
@@ -1,6 +1,7 @@
 package com.hyunec.cosmicbaseballinit.domain.baseball.web;
 
 import com.hyunec.cosmicbaseballinit.domain.baseball.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.domain.baseball.model.GameEntity;
 import com.hyunec.cosmicbaseballinit.domain.baseball.service.GameService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,5 +18,10 @@ public class GameController {
     @GetMapping("/game/batting")
     public BattingResult batting() {
         return gameService.batting();
+    }
+
+    @GetMapping("/game/init")
+    public GameEntity initGame() {
+        return gameService.initGame();
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -3,13 +3,32 @@ package com.hyunec.cosmicbaseballinit.acceptancetest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hyunec.cosmicbaseballinit.domain.baseball.model.Batting;
+import com.hyunec.cosmicbaseballinit.domain.baseball.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.domain.baseball.model.GameEntity;
+import com.hyunec.cosmicbaseballinit.domain.baseball.repository.PlateAppearances;
+import com.hyunec.cosmicbaseballinit.domain.baseball.service.GameService;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class NormalBaseballLv1Test {
+
+    @Autowired
+    GameService gameService;
+
+    @Autowired
+    PlateAppearances plateAppearances;
+
+    @BeforeEach
+    void setup() {
+        plateAppearances.clear();
+    }
 
     @DisplayName("strike, ball, hit 는 같은 확률 입니다.")
     @RepeatedTest(value = 100)
@@ -37,24 +56,70 @@ class NormalBaseballLv1Test {
     @DisplayName("3B 타석에서 타격 결과가 ball 이면 타석 결과는 four_ball 됩니다.")
     @Test
     void t2() {
-        throw new RuntimeException("Not yet implemented");
+        // Given
+        plateAppearances.batting(Batting.BALL);
+        plateAppearances.batting(Batting.BALL);
+        plateAppearances.batting(Batting.BALL);
+
+        // When
+        plateAppearances.batting(Batting.BALL);
+
+        // Then
+        assertThat(plateAppearances.result()).isNotEqualTo(BattingResult.OUT);
+        assertThat(plateAppearances.result()).isEqualTo(BattingResult.FOUR_BALL);
     }
 
     @DisplayName("2S 타석에서 타격 결과가 strike 이면 타석 결과는 out 됩니다.")
     @Test
     void t3() {
-        throw new RuntimeException("Not yet implemented");
+        // Given
+        plateAppearances.batting(Batting.STRIKE);
+        plateAppearances.batting(Batting.STRIKE);
+
+        // When
+        plateAppearances.batting(Batting.STRIKE);
+
+        // Then
+        assertThat(plateAppearances.result()).isEqualTo(BattingResult.OUT);
     }
 
     @DisplayName("진행 중인 타석이 있는 상태에서 새로운 타석을 진행할 수 없습니다.")
     @Test
     void t4() {
-        throw new RuntimeException("Not yet implemented");
+        plateAppearances.batting(Batting.STRIKE);
+        assertThat(gameService.initGame())
+            .isEqualTo(
+                GameEntity.builder().message("아직 게임이 끝나지 않았습니다.").build()
+            );
+
+
     }
 
     @DisplayName("타석이 종료되면 초기화하여 새로 진행할 수 있습니다.")
     @Test
     void t5() {
-        throw new RuntimeException("Not yet implemented");
+        // Given
+        plateAppearances.batting(Batting.STRIKE);
+        plateAppearances.batting(Batting.STRIKE);
+        plateAppearances.batting(Batting.STRIKE);
+        // When
+        // Then
+
+        assertThat(gameService.initGame()).isEqualTo(
+            GameEntity.builder().message("새로운 게임이 생성되었습니다.").build()
+        );
+
+        plateAppearances.batting(Batting.HIT);
+        assertThat(gameService.initGame()).isEqualTo(
+            GameEntity.builder().message("새로운 게임이 생성되었습니다.").build()
+        );
+
+        plateAppearances.batting(Batting.BALL);
+        plateAppearances.batting(Batting.BALL);
+        plateAppearances.batting(Batting.BALL);
+        plateAppearances.batting(Batting.BALL);
+        assertThat(gameService.initGame()).isEqualTo(
+            GameEntity.builder().message("새로운 게임이 생성되었습니다.").build()
+        );
     }
 }


### PR DESCRIPTION
- ~~[x]  기존 프로젝트 레이어드 아키텍쳐에 맞게 리팩토링~~
    - ~~[x]  PlateApprearance를 퍼시스턴스로 분리~~
    - ~~[x]  batting 서비스 클래스~~
    - ~~[x]  기존 /game/batting 컨트롤러에 서비스 연결~~
    - ~~[x]  테스트 - 배팅 유틸 메서드 Random test~~
- [x]  initGame 서비스 메서드 구현, 컨트롤러 메서드 연결
    - [x]  테스트 - 4볼이면 게임 종료
    - [x]  테스트 - 3스트라이크이면 게임 종료
    - [x]  컨트롤러 연결
- [x]  게임 진행 구현
    - [x]  테스트 - 진행 중인 타석이 있으면 새로운 타석을 진행할 수 없음
    - [x]  테스트 - 타석이 종료되면 초기화해서 새로 진행할 수 있음

저번에 말씀하신 대로 mock 객체를 사용하지 않고 테스트를 작성해보았습니다. 

풀면서 겪은 점
1. Exception을 정의해서 사용하는게 익숙하지 않아서 불편해서 대신 상태값을 체크하는 메서드를 퍼시스턴트 레이어(plateAppeareance 클래스) 에서 작성하였음. 이 방식으로 하면 Exception을 사용하지 않음. 

2. 상수 문자열로 에러메세지를 정의해서 재사용하지 않았음

3. @SpringBootTest 를 사용하니 테스트실행이 너무 느림

4. 테스트를 먼저 작성하고 싶은데 결국 퍼시스턴스 -> 서비스 -> 컨트롤러 순으로 코드를 구성하고 테스트를 작성한 뒤에 다시 서비스 코드를 작성하는 순으로 작성함

5. 테스트를 짜다보니 gameService를 테스트하는 코드보다 plateAppearance의 상태값을 테스트하는 코드가 더 많아짐. 서비스 레이어를 테스트하는게 목적 아니였는지 의문