### PR TITLE
타격 상태 추가, 인수테스트

### DIFF
--- a/src/main/java/com/hyunec/cosmicbaseballinit/batter/domain/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/batter/domain/BattingResult.java
@@ -1,5 +1,5 @@
 package com.hyunec.cosmicbaseballinit.batter.domain;
 
 public enum BattingResult {
-    STRIKE, BALL, HIT
+    STRIKE, BALL, HIT, DOUBLE_STRIKE, DOUBLE_BALL
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
@@ -1,18 +1,53 @@
 package com.hyunec.cosmicbaseballinit.acceptancetest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hyunec.cosmicbaseballinit.batter.domain.BattingResult;
+import com.hyunec.cosmicbaseballinit.batter.service.BattingFactory;
+import com.hyunec.cosmicbaseballinit.batter.service.RandomBattingFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class CosmicBaseballLv1Test {
+
+    static List<BattingResult> results = new ArrayList<>();
+
+    @BeforeAll
+    static void setUp() {
+        // given
+        BattingFactory factory = new RandomBattingFactory();
+        IntStream.range(0, 100).forEach(i -> {
+            BattingResult result = factory.generate();
+            results.add(result);
+        });
+    }
+
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
     @Test
     void t1() {
-        throw new RuntimeException("Not yet implemented");
+        // then
+        long strikeCount = results.stream().filter(result -> result == BattingResult.STRIKE).count();
+        long ballCount = results.stream().filter(result -> result == BattingResult.BALL).count();
+        long hitCount = results.stream().filter(result -> result == BattingResult.HIT).count();
+        long doubleBallCount = results.stream().filter(result -> result == BattingResult.DOUBLE_BALL).count();
+        long doubleStrikeCount = results.stream().filter(result -> result == BattingResult.DOUBLE_STRIKE).count();
+
+        assertThat(strikeCount + ballCount + hitCount + doubleBallCount + doubleStrikeCount).isEqualTo(100);
     }
 
     @DisplayName("타격 결과는 strike, ball, hit, double_ball, double_strike 입니다.")
     @Test
     void t2() {
-        throw new RuntimeException("Not yet implemented");
+        assertThat(results).contains(
+            BattingResult.STRIKE,
+            BattingResult.BALL,
+            BattingResult.HIT,
+            BattingResult.DOUBLE_BALL,
+            BattingResult.DOUBLE_STRIKE
+        );
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
@@ -6,7 +6,9 @@ import com.hyunec.cosmicbaseballinit.batter.domain.BattingResult;
 import com.hyunec.cosmicbaseballinit.batter.service.BattingFactory;
 import com.hyunec.cosmicbaseballinit.batter.service.RandomBattingFactory;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -29,14 +31,14 @@ class CosmicBaseballLv1Test {
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
     @Test
     void t1() {
-        // then
-        long strikeCount = results.stream().filter(result -> result == BattingResult.STRIKE).count();
-        long ballCount = results.stream().filter(result -> result == BattingResult.BALL).count();
-        long hitCount = results.stream().filter(result -> result == BattingResult.HIT).count();
-        long doubleBallCount = results.stream().filter(result -> result == BattingResult.DOUBLE_BALL).count();
-        long doubleStrikeCount = results.stream().filter(result -> result == BattingResult.DOUBLE_STRIKE).count();
+        // when
+        Map<BattingResult, Integer> counts = new HashMap<>();
+        for (BattingResult result : results) {
+            counts.put(result, counts.getOrDefault(result, 0) + 1);
+        }
 
-        assertThat(strikeCount + ballCount + hitCount + doubleBallCount + doubleStrikeCount).isEqualTo(100);
+        // then
+        assertThat(counts.values().stream().mapToInt(Integer::intValue).sum()).isEqualTo(100);
     }
 
     @DisplayName("타격 결과는 strike, ball, hit, double_ball, double_strike 입니다.")

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -7,7 +7,9 @@ import com.hyunec.cosmicbaseballinit.batter.domain.BattingResult;
 import com.hyunec.cosmicbaseballinit.batter.service.BattingStrategy;
 import com.hyunec.cosmicbaseballinit.batter.service.RandomBattingStrategy;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -31,12 +33,14 @@ class NormalBaseballLv1Test {
     @DisplayName("strike, ball, hit 는 같은 확률 입니다.")
     @Test
     void t1() {
-        // then
-        long strikeCount = results.stream().filter(result -> result == BattingResult.STRIKE).count();
-        long ballCount = results.stream().filter(result -> result == BattingResult.BALL).count();
-        long hitCount = results.stream().filter(result -> result == BattingResult.HIT).count();
+        // when
+        Map<BattingResult, Integer> counts = new HashMap<>();
+        for (BattingResult result : results) {
+            counts.put(result, counts.getOrDefault(result, 0) + 1);
+        }
 
-        assertThat(strikeCount + ballCount + hitCount).isEqualTo(100);
+        // then
+        assertThat(counts.values().stream().mapToInt(Integer::intValue).sum()).isEqualTo(100);
     }
 
     @DisplayName("타격 결과는 strike, ball, hit 입니다.")


### PR DESCRIPTION
![Screenshot 2023-03-07 at 3 56 43 PM](https://user-images.githubusercontent.com/25076126/223347127-49ecd1df-7723-401a-9632-b297823d8517.png)

- DOUBLE_STRIKE, DOUBLE_BALL 상태 추가(BattingResult 클래스)
- 그에 따른 이전 레벨의 인수테스트 수정(NormalBaseballLv1Test 클래스)
- 해당 레벨 인수테스트 작성(CosmicBaseballLv1Test 클래스)

