### PR TITLE
일반야구 Lv1. 구현

### DIFF
--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -7,13 +7,13 @@ import java.util.Random;
 
 @Component
 public class RandomUtils {
-    private static final Random random = new Random();
+    private static final Random RANDOM = new Random();
 
     private RandomUtils() {
     }
 
     public static BattingResult getRandomBattingResult() {
-        int value = random.nextInt(3);
+        int value = RANDOM.nextInt(3);
 
         switch (value) {
             case 0:

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -1,0 +1,24 @@
+package com.hyunec.cosmicbaseballinit.common;
+
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class RandomUtils {
+    private final Random random = new Random();
+
+    public BattingResult getRandomBattingResult() {
+        int value = random.nextInt(3);
+
+        switch (value) {
+            case 0:
+                return BattingResult.STRIKE;
+            case 1:
+                return BattingResult.BALL;
+            default:
+                return BattingResult.HIT;
+        }
+    }
+}

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -7,9 +7,13 @@ import java.util.Random;
 
 @Component
 public class RandomUtils {
-    private final Random random = new Random();
+    private static final Random random = new Random();
 
-    public BattingResult getRandomBattingResult() {
+    private RandomUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static BattingResult getRandomBattingResult() {
         int value = random.nextInt(3);
 
         switch (value) {

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -10,7 +10,6 @@ public class RandomUtils {
     private static final Random random = new Random();
 
     private RandomUtils() {
-        throw new IllegalStateException("Utility class");
     }
 
     public static BattingResult getRandomBattingResult() {

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -1,27 +1,27 @@
 package com.hyunec.cosmicbaseballinit.common;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
-import org.springframework.stereotype.Component;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.Random;
 
-@Component
+import static com.hyunec.cosmicbaseballinit.model.BattingResult.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RandomUtils {
     private static final Random RANDOM = new Random();
-
-    private RandomUtils() {
-    }
 
     public static BattingResult getRandomBattingResult() {
         int value = RANDOM.nextInt(3);
 
         switch (value) {
             case 0:
-                return BattingResult.STRIKE;
+                return STRIKE;
             case 1:
-                return BattingResult.BALL;
+                return BALL;
             default:
-                return BattingResult.HIT;
+                return HIT;
         }
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -1,0 +1,7 @@
+package com.hyunec.cosmicbaseballinit.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class BattingController {
+}

--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -1,22 +1,24 @@
 package com.hyunec.cosmicbaseballinit.controller;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
-import com.hyunec.cosmicbaseballinit.service.BattingService;
+import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Controller
 @RequiredArgsConstructor
 public class BattingController {
 
-    private final BattingService battingService;
+    private final BattingServiceImpl battingServiceImpl;
 
     @GetMapping("/batting")
     public ResponseEntity<BattingResult> getBattingResult() {
-        BattingResult result = battingService.batting();
+        BattingResult result = battingServiceImpl.batting();
 
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -3,23 +3,17 @@ package com.hyunec.cosmicbaseballinit.controller;
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@Controller
 @RequiredArgsConstructor
 public class BattingController {
 
     private final BattingServiceImpl battingServiceImpl;
 
     @GetMapping("/batting")
-    public ResponseEntity<BattingResult> getBattingResult() {
-        BattingResult result = battingServiceImpl.batting();
-
-        return new ResponseEntity<>(result, HttpStatus.OK);
+    public BattingResult getBattingResult() {
+        return battingServiceImpl.batting();
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -1,7 +1,23 @@
 package com.hyunec.cosmicbaseballinit.controller;
 
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.service.BattingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class BattingController {
+
+    private final BattingService battingService;
+
+    @GetMapping("/batting")
+    public ResponseEntity<BattingResult> getBattingResult() {
+        BattingResult result = battingService.batting();
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
@@ -6,9 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum BattingResult {
-    STRIKE(0.3),
-    BALL(0.3),
-    HIT(0.3);
+    STRIKE,
+    BALL,
+    HIT
 
-    private final double probability;
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
@@ -1,0 +1,14 @@
+package com.hyunec.cosmicbaseballinit.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BattingResult {
+    STRIKE(0.3),
+    BALL(0.3),
+    HIT(0.3);
+
+    private final double probability;
+}

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -8,9 +8,9 @@ import java.util.Random;
 @Service
 public class BattingService {
 
-    public BattingResult batting() {
+    private final Random random = new Random();
 
-        Random random = new Random();
+    public BattingResult batting() {
 
         int value = random.nextInt(3);
 

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -1,26 +1,17 @@
 package com.hyunec.cosmicbaseballinit.service;
 
+import com.hyunec.cosmicbaseballinit.common.RandomUtils;
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Random;
-
 @Service
+@RequiredArgsConstructor
 public class BattingService {
 
-    private final Random random = new Random();
+    private final RandomUtils randomUtils;
 
     public BattingResult batting() {
-
-        int value = random.nextInt(3);
-
-        switch (value) {
-            case 0:
-                return BattingResult.STRIKE;
-            case 1:
-                return BattingResult.BALL;
-            default:
-                return BattingResult.HIT;
-        }
+        return randomUtils.getRandomBattingResult();
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -1,17 +1,7 @@
 package com.hyunec.cosmicbaseballinit.service;
 
-import com.hyunec.cosmicbaseballinit.common.RandomUtils;
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class BattingService {
-
-    private final RandomUtils randomUtils;
-
-    public BattingResult batting() {
-        return randomUtils.getRandomBattingResult();
-    }
+public interface BattingService {
+    BattingResult batting();
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -1,7 +1,26 @@
 package com.hyunec.cosmicbaseballinit.service;
 
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import org.springframework.stereotype.Service;
+
+import java.util.Random;
 
 @Service
 public class BattingService {
+
+    public BattingResult batting() {
+
+        Random random = new Random();
+
+        int value = random.nextInt(3);
+
+        switch (value) {
+            case 0:
+                return BattingResult.STRIKE;
+            case 1:
+                return BattingResult.BALL;
+            default:
+                return BattingResult.HIT;
+        }
+    }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -1,0 +1,7 @@
+package com.hyunec.cosmicbaseballinit.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BattingService {
+}

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
@@ -9,10 +9,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BattingServiceImpl implements BattingService {
 
-    private final RandomUtils randomUtils;
-
     @Override
     public BattingResult batting() {
-        return randomUtils.getRandomBattingResult();
+        return RandomUtils.getRandomBattingResult();
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
@@ -1,0 +1,18 @@
+package com.hyunec.cosmicbaseballinit.service;
+
+import com.hyunec.cosmicbaseballinit.common.RandomUtils;
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BattingServiceImpl implements BattingService {
+
+    private final RandomUtils randomUtils;
+
+    @Override
+    public BattingResult batting() {
+        return randomUtils.getRandomBattingResult();
+    }
+}

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -2,12 +2,17 @@ package com.hyunec.cosmicbaseballinit.acceptancetest;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.hyunec.cosmicbaseballinit.model.BattingResult.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class NormalBaseballLv1Test {
@@ -45,7 +50,8 @@ class NormalBaseballLv1Test {
         double ballProbability = Math.round(ballCount / caseSize * 10) / 10F;
         double hitProbability = Math.round(hitCount / caseSize * 10) / 10F;
 
-        Assertions.assertTrue(strikeProbability == ballProbability && ballProbability == hitProbability);
+        assertThat(strikeProbability == ballProbability && ballProbability == hitProbability)
+                .isTrue();
     }
 
     @DisplayName("타격 결과는 strike, ball, hit 입니다.")
@@ -54,10 +60,9 @@ class NormalBaseballLv1Test {
 
         BattingResult result = battingServiceImpl.batting();
 
-        boolean validResult = result.equals(BattingResult.HIT)
-                || result.equals(BattingResult.STRIKE)
-                || result.equals(BattingResult.BALL);
+        List<BattingResult> validResult = Stream.of(STRIKE, BALL, HIT).collect(Collectors.toList());
 
-        Assertions.assertTrue(validResult);
+        assertThat(result)
+                .isIn(validResult);
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -1,7 +1,7 @@
 package com.hyunec.cosmicbaseballinit.acceptancetest;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
-import com.hyunec.cosmicbaseballinit.service.BattingService;
+import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 class NormalBaseballLv1Test {
 
     @Autowired
-    private BattingService battingService;
+    private BattingServiceImpl battingServiceImpl;
 
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
     @Test
@@ -26,7 +26,7 @@ class NormalBaseballLv1Test {
         double caseSize = 150000;
 
         for (double i = 0; i < caseSize; i++) {
-            BattingResult result = battingService.batting();
+            BattingResult result = battingServiceImpl.batting();
 
             switch (result) {
                 case STRIKE:
@@ -52,7 +52,7 @@ class NormalBaseballLv1Test {
     @Test
     void t2() {
 
-        BattingResult result = battingService.batting();
+        BattingResult result = battingServiceImpl.batting();
 
         boolean validResult = result.equals(BattingResult.HIT)
                 || result.equals(BattingResult.STRIKE)

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -2,7 +2,9 @@ package com.hyunec.cosmicbaseballinit.acceptancetest;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,37 +23,22 @@ class NormalBaseballLv1Test {
     private BattingServiceImpl battingServiceImpl;
 
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
-    @Test
+    @RepeatedTest(100)
     void t1() {
 
-        double strikeCount = 0;
-        double ballCount = 0;
-        double hitCount = 0;
+        double caseSize = 100000;
+        double count = 0;
 
-        double caseSize = 150000;
+        BattingResult randomResult = battingServiceImpl.batting();
 
         for (double i = 0; i < caseSize; i++) {
             BattingResult result = battingServiceImpl.batting();
-
-            switch (result) {
-                case STRIKE:
-                    strikeCount += 1;
-                    break;
-                case BALL:
-                    ballCount += 1;
-                    break;
-                case HIT:
-                    hitCount += 1;
-                    break;
+            if (randomResult == result) {
+                count++;
             }
         }
 
-        double strikeProbability = Math.round(strikeCount / caseSize * 10) / 10F;
-        double ballProbability = Math.round(ballCount / caseSize * 10) / 10F;
-        double hitProbability = Math.round(hitCount / caseSize * 10) / 10F;
-
-        assertThat(strikeProbability == ballProbability && ballProbability == hitProbability)
-                .isTrue();
+        assertThat(count).isCloseTo(33333, Percentage.withPercentage(5));
     }
 
     @DisplayName("타격 결과는 strike, ball, hit 입니다.")

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv1Test.java
@@ -1,18 +1,63 @@
 package com.hyunec.cosmicbaseballinit.acceptancetest;
 
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.service.BattingService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+
+@SpringBootTest
 class NormalBaseballLv1Test {
+
+    @Autowired
+    private BattingService battingService;
+
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
     @Test
     void t1() {
-        throw new RuntimeException("Not yet implemented");
+
+        double strikeCount = 0;
+        double ballCount = 0;
+        double hitCount = 0;
+
+        double caseSize = 150000;
+
+        for (double i = 0; i < caseSize; i++) {
+            BattingResult result = battingService.batting();
+
+            switch (result) {
+                case STRIKE:
+                    strikeCount += 1;
+                    break;
+                case BALL:
+                    ballCount += 1;
+                    break;
+                case HIT:
+                    hitCount += 1;
+                    break;
+            }
+        }
+
+        double strikeProbability = Math.round(strikeCount / caseSize * 10) / 10F;
+        double ballProbability = Math.round(ballCount / caseSize * 10) / 10F;
+        double hitProbability = Math.round(hitCount / caseSize * 10) / 10F;
+
+        Assertions.assertTrue(strikeProbability == ballProbability && ballProbability == hitProbability);
     }
 
     @DisplayName("타격 결과는 strike, ball, hit 입니다.")
     @Test
     void t2() {
-        throw new RuntimeException("Not yet implemented");
+
+        BattingResult result = battingService.batting();
+
+        boolean validResult = result.equals(BattingResult.HIT)
+                || result.equals(BattingResult.STRIKE)
+                || result.equals(BattingResult.BALL);
+
+        Assertions.assertTrue(validResult);
     }
 }


### PR DESCRIPTION
## 구현 내용
- 타격 결과를 리턴하는 api 구현
- 타격 결과는 strike, ball, hit 테스트 구현
![스크린샷 2023-04-07 오후 3 57 07](https://user-images.githubusercontent.com/67693142/230558298-4aaf9e90-dbbc-4d79-bee9-f2c26fdfc705.png)


## 질문 내용
- [타격 결과는 모두 같은 확률을 가집니다] 테스트를 아래처럼 구현했습니다. 

> - 서비스 로직을 N회 실행
> - 서비스 로직이 리턴하는 안타, 스트라이크, 볼의 횟수 기록
> - 3가지 결과의 확률이 동일한지 확인
> - 3가지 결과의 확률이 0.3으로 동일하도록, 1번째 자리까지 반올림

그런데 테스트 반복 횟수를 작게 설정하면(약 1000회) 테스트가 실패하는 경우가 있었습니다. 
이렇게 랜덤 케이스들을 반복해 확률을 계산하는 방식 대신 다른 방식을 선택해야 할지 궁금합니다.
