### PR TITLE
우주야구 Lv1 구현

### DIFF
--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomGenerator.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomGenerator.java
@@ -6,10 +6,6 @@ import lombok.NoArgsConstructor;
 import java.util.Random;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class RandomUtils {
-    private static final Random RANDOM = new Random();
-
-    public static int getRandomBattingNumber() {
-        return RANDOM.nextInt(5);
-    }
+public class RandomGenerator {
+    public static final Random RANDOM = new Random();
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -13,13 +13,17 @@ public class RandomUtils {
     private static final Random RANDOM = new Random();
 
     public static BattingResult getRandomBattingResult() {
-        int value = RANDOM.nextInt(3);
+        int value = RANDOM.nextInt(5);
 
         switch (value) {
             case 0:
                 return STRIKE;
             case 1:
                 return BALL;
+            case 2:
+                return DOUBLE_STRIKE;
+            case 3:
+                return DOUBLE_BALL;
             default:
                 return HIT;
         }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/common/RandomUtils.java
@@ -1,31 +1,15 @@
 package com.hyunec.cosmicbaseballinit.common;
 
-import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.util.Random;
 
-import static com.hyunec.cosmicbaseballinit.model.BattingResult.*;
-
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RandomUtils {
     private static final Random RANDOM = new Random();
 
-    public static BattingResult getRandomBattingResult() {
-        int value = RANDOM.nextInt(5);
-
-        switch (value) {
-            case 0:
-                return STRIKE;
-            case 1:
-                return BALL;
-            case 2:
-                return DOUBLE_STRIKE;
-            case 3:
-                return DOUBLE_BALL;
-            default:
-                return HIT;
-        }
+    public static int getRandomBattingNumber() {
+        return RANDOM.nextInt(5);
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 public enum BattingResult {
     STRIKE,
     BALL,
-    HIT
+    HIT,
+    DOUBLE_STRIKE,
+    DOUBLE_BALL
 
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
@@ -10,6 +10,20 @@ public enum BattingResult {
     BALL,
     HIT,
     DOUBLE_STRIKE,
-    DOUBLE_BALL
+    DOUBLE_BALL;
 
+    public static BattingResult getBattingResult(int value) {
+        switch (value) {
+            case 0:
+                return STRIKE;
+            case 1:
+                return BALL;
+            case 2:
+                return DOUBLE_STRIKE;
+            case 3:
+                return DOUBLE_BALL;
+            default:
+                return HIT;
+        }
+    }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
@@ -11,6 +11,7 @@ public class BattingServiceImpl implements BattingService {
 
     @Override
     public BattingResult batting() {
-        return RandomUtils.getRandomBattingResult();
+        int value = RandomUtils.getRandomBattingNumber();
+        return BattingResult.getBattingResult(value);
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
@@ -1,6 +1,6 @@
 package com.hyunec.cosmicbaseballinit.service;
 
-import com.hyunec.cosmicbaseballinit.common.RandomUtils;
+import com.hyunec.cosmicbaseballinit.common.RandomGenerator;
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,7 @@ public class BattingServiceImpl implements BattingService {
 
     @Override
     public BattingResult batting() {
-        int value = RandomUtils.getRandomBattingNumber();
+        int value = RandomGenerator.RANDOM.nextInt(5);
         return BattingResult.getBattingResult(value);
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
@@ -25,12 +25,12 @@ class CosmicBaseballLv1Test {
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
     @RepeatedTest(100)
     void t1() {
-        double caseSize = 100000;
-        double count = 0;
+        int caseSize = 100000;
+        int count = 0;
 
         BattingResult randomResult = battingServiceImpl.batting();
 
-        for (double i = 0; i < caseSize; i++) {
+        for (int i = 0; i < caseSize; i++) {
             BattingResult result = battingServiceImpl.batting();
             if (randomResult == result) {
                 count++;

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
@@ -1,18 +1,53 @@
 package com.hyunec.cosmicbaseballinit.acceptancetest;
 
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.hyunec.cosmicbaseballinit.model.BattingResult.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
 class CosmicBaseballLv1Test {
+
+    @Autowired
+    private BattingServiceImpl battingServiceImpl;
+
     @DisplayName("타격 결과는 모두 같은 확률을 가집니다.")
-    @Test
+    @RepeatedTest(100)
     void t1() {
-        throw new RuntimeException("Not yet implemented");
+        double caseSize = 100000;
+        double count = 0;
+
+        BattingResult randomResult = battingServiceImpl.batting();
+
+        for (double i = 0; i < caseSize; i++) {
+            BattingResult result = battingServiceImpl.batting();
+            if (randomResult == result) {
+                count++;
+            }
+        }
+
+        assertThat(count).isCloseTo(caseSize / 5, Percentage.withPercentage(5));
     }
 
     @DisplayName("타격 결과는 strike, ball, hit, double_ball, double_strike 입니다.")
     @Test
     void t2() {
-        throw new RuntimeException("Not yet implemented");
+        BattingResult result = battingServiceImpl.batting();
+
+        List<BattingResult> validResult = Stream.of(STRIKE, BALL, HIT, DOUBLE_STRIKE, DOUBLE_BALL).collect(Collectors.toList());
+
+        assertThat(result)
+                .isIn(validResult);
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/CosmicBaseballLv1Test.java
@@ -28,11 +28,11 @@ class CosmicBaseballLv1Test {
         int caseSize = 100000;
         int count = 0;
 
-        BattingResult randomResult = battingServiceImpl.batting();
+        BattingResult expected = battingServiceImpl.batting();
 
         for (int i = 0; i < caseSize; i++) {
             BattingResult result = battingServiceImpl.batting();
-            if (randomResult == result) {
+            if (expected == result) {
                 count++;
             }
         }


### PR DESCRIPTION
## 구현 내용
- double ball, double strike 케이스 추가
- 랜덤 타격 결과를 리턴하는 로직을 BattingResult enum 내로 이동

![스크린샷 2023-04-15 오후 9 37 42](https://user-images.githubusercontent.com/67693142/232224086-fe3b9a3d-00bd-4ea1-be3e-567a3a5aa648.png)

우주야구 Lv1 구현해 보았습니다!
기존의 일반야구 Lv1의 랜덤 로직 관련한 리팩토링도 추가해서 커밋했습니다.