### PR TITLE
일반야구 Lv2. 구현 추가

### DIFF
--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -1,6 +1,7 @@
 package com.hyunec.cosmicbaseballinit.controller;
 
 import com.hyunec.cosmicbaseballinit.model.BattingResult;
+import com.hyunec.cosmicbaseballinit.model.PlateStatus;
 import com.hyunec.cosmicbaseballinit.service.BattingServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,5 +16,10 @@ public class BattingController {
     @GetMapping("/batting")
     public BattingResult getBattingResult() {
         return battingServiceImpl.batting();
+    }
+
+    @GetMapping("/plateStatus")
+    public PlateStatus getPlateStatus() {
+        return new PlateStatus(); // TODO 추가필요
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/controller/BattingController.java
@@ -19,7 +19,7 @@ public class BattingController {
     }
 
     @GetMapping("/plateStatus")
-    public PlateStatus getPlateStatus() {
-        return new PlateStatus(); // TODO 추가필요
+    public PlateStatus getPlateStatus() throws Exception {
+        return battingServiceImpl.getPlateStatus();
     }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/BattingResult.java
@@ -6,11 +6,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum BattingResult {
-    STRIKE,
-    BALL,
-    HIT,
-    DOUBLE_STRIKE,
-    DOUBLE_BALL;
+    STRIKE(1, 0),
+    BALL(0, 1),
+    HIT(0, 0),
+    DOUBLE_STRIKE(2, 0),
+    DOUBLE_BALL(0, 2);
+
+    private final int strikeCount;
+    private final int ballCount;
 
     public static BattingResult getBattingResult(int value) {
         switch (value) {

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
@@ -32,10 +32,10 @@ public class PlateStatus {
     }
 
     public BatterStatus getBatterStatus() {
-        if (this.ballCount >= 4 || this.getHitCount() == 1) {
+        if (ballCount >= 4 || hitCount == 1) {
             return ADVANCE;
         }
-        if (this.getStrikeCount() >= 3) {
+        if (strikeCount >= 3) {
             return OUT;
         }
         return STAY;

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
@@ -28,4 +28,11 @@ public class PlateStatus {
         }
         return STAY;
     }
+
+    public Boolean checkInitialStatus() {
+        if (strikeCount == 0 && ballCount == 0 && hitCount == 0 && batterStatus.equals(STAY)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
@@ -12,23 +12,8 @@ public class PlateStatus {
     private int hitCount = 0;
 
     public void updateBatterResult(BattingResult result) {
-        switch (result) {
-            case STRIKE:
-                this.strikeCount++;
-                break;
-            case BALL:
-                this.ballCount++;
-                break;
-            case DOUBLE_STRIKE:
-                this.strikeCount += 2;
-                break;
-            case DOUBLE_BALL:
-                this.ballCount += 2;
-                break;
-            default:
-                this.hitCount++;
-                break;
-        }
+        strikeCount += result.getStrikeCount();
+        ballCount += result.getBallCount();
     }
 
     public BatterStatus getBatterStatus() {

--- a/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/model/PlateStatus.java
@@ -12,6 +12,9 @@ public class PlateStatus {
     private int hitCount = 0;
 
     public void updateBatterResult(BattingResult result) {
+        if (result.equals(BattingResult.HIT)) {
+            hitCount++;
+        }
         strikeCount += result.getStrikeCount();
         ballCount += result.getBallCount();
     }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingService.java
@@ -6,5 +6,5 @@ import com.hyunec.cosmicbaseballinit.model.PlateStatus;
 public interface BattingService {
     BattingResult batting();
 
-    PlateStatus updatePlateStatus(PlateStatus plateStatus);
+    PlateStatus getPlateStatus() throws Exception;
 }

--- a/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
+++ b/src/main/java/com/hyunec/cosmicbaseballinit/service/BattingServiceImpl.java
@@ -17,9 +17,14 @@ public class BattingServiceImpl implements BattingService {
     }
 
     @Override
-    public PlateStatus updatePlateStatus(PlateStatus plateStatus) {
-        BattingResult result = batting();
-        plateStatus.updateBatterResult(result);
-        return plateStatus;
+    public PlateStatus getPlateStatus() throws Exception {
+        PlateStatus plateStatus = new PlateStatus();
+        if (plateStatus.checkInitialStatus()) {
+            BattingResult result = batting();
+            plateStatus.updateBatterResult(result);
+            return plateStatus;
+        } else {
+            throw new Exception();
+        }
     }
 }

--- a/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv2Test.java
+++ b/src/test/java/com/hyunec/cosmicbaseballinit/acceptancetest/NormalBaseballLv2Test.java
@@ -1,6 +1,7 @@
 package com.hyunec.cosmicbaseballinit.acceptancetest;
 
 import com.hyunec.cosmicbaseballinit.model.BatterStatus;
+import com.hyunec.cosmicbaseballinit.model.BattingResult;
 import com.hyunec.cosmicbaseballinit.model.PlateStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -10,8 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.stream.Stream;
 
-import static com.hyunec.cosmicbaseballinit.model.BattingResult.DOUBLE_STRIKE;
-import static com.hyunec.cosmicbaseballinit.model.BattingResult.STRIKE;
+import static com.hyunec.cosmicbaseballinit.model.BattingResult.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -31,47 +31,41 @@ class NormalBaseballLv2Test {
                     assertThat(plateStatus.getBatterStatus()).isEqualTo(BatterStatus.STAY);
                 }),
                 DynamicTest.dynamicTest("0 strike 상태의 타석에서 타격 결과가 strike 이면 타석 결과는 진행 중 입니다.", () -> {
-                    plateStatus.updateBatterResult(STRIKE);
-                    BatterStatus batterStatus = plateStatus.getBatterStatus();
+                    BatterStatus batterStatus = updateAndGetBatterStatus(plateStatus, STRIKE);
                     assertThat(batterStatus).isEqualTo(BatterStatus.STAY);
                 }),
                 DynamicTest.dynamicTest("1 strike 상태의 타석에서 타격 결과가 double_strike 이면 타석 결과는 out 입니다.", () -> {
-                    plateStatus.updateBatterResult(DOUBLE_STRIKE);
-                    BatterStatus batterStatus = plateStatus.getBatterStatus();
+                    BatterStatus batterStatus = updateAndGetBatterStatus(plateStatus, DOUBLE_STRIKE);
                     assertThat(batterStatus).isEqualTo(BatterStatus.OUT);
                 })
         );
     }
 
-    @DisplayName("ball 타석 결과와 관련된 테스트를 진행합니다.")
+    @DisplayName("ball, hit 타석 결과와 관련된 테스트를 진행합니다.")
     @TestFactory
     Stream<DynamicTest> normalBaseBallLv2TestBallCollection() {
+
+        PlateStatus plateStatus = new PlateStatus();
+
         return Stream.of(
-                DynamicTest.dynamicTest("새로운 타석이 시작되면 타석 상태를 초기화 합니다.", () -> {
-
-                }),
                 DynamicTest.dynamicTest("0 ball 상태의 타석에서 타격 결과가 ball 이면 타석 결과는 진행 중 입니다.", () -> {
-
+                    BatterStatus batterStatus = updateAndGetBatterStatus(plateStatus, BALL);
+                    assertThat(batterStatus).isEqualTo(BatterStatus.STAY);
                 }),
-                DynamicTest.dynamicTest("진행 중인 타석이 있는 상태에서 새로운 타석을 진행할 수 없습니다.", () -> {
-
+                DynamicTest.dynamicTest("1 ball 상태의 타석에서 타격 결과가 double_ball 이면 타석 결과는 three_ball 으로 진행 중 입니다.", () -> {
+                    BatterStatus batterStatus = updateAndGetBatterStatus(plateStatus, DOUBLE_BALL);
+                    assertThat(batterStatus).isEqualTo(BatterStatus.STAY);
                 }),
-                DynamicTest.dynamicTest("0 ball 상태의 타석에서 타격 결과가 double_ball 이면 타석 결과는 진행 중 입니다.", () -> {
-
-                }),
-                DynamicTest.dynamicTest("2 ball 상태의 타석에서 타격 결과가 double_ball 이면 타석 결과는 four_ball 으로 진루 입니다.", () -> {
-
-                }),
-                DynamicTest.dynamicTest("3 ball 상태의 타석에서 타격 결과가 ball 이면 타석 결과는 four_ball 으로 진루 입니다.", () -> {
-
+                DynamicTest.dynamicTest("타석 결과가 hit 이면 기존 상태와 관계없이 hit 으로 진루 합니다.", () -> {
+                    BatterStatus batterStatus = updateAndGetBatterStatus(plateStatus, HIT);
+                    assertThat(batterStatus).isEqualTo(BatterStatus.ADVANCE);
                 })
         );
     }
 
-    @DisplayName("타석 결과가 hit 이면 타석 결과는 hit 로 진루 입니다.")
-    @Test
-    void t10() {
-        throw new RuntimeException("Not yet implemented");
+    public BatterStatus updateAndGetBatterStatus(PlateStatus plateStatus, BattingResult result) {
+        plateStatus.updateBatterResult(result);
+        return plateStatus.getBatterStatus();
     }
 
     @DisplayName("진행 중인 타석이 있는 상태에서 새로운 타석을 진행할 수 없습니다.")


### PR DESCRIPTION
## 구현 내용

타석 결과 관련 로직과 시나리오 테스트를 추가했습니다.

- 타석 결과를 리턴하는 Controller, Service 구조 추가
- 최초 타석 상태인지 판단하는 로직 추가
- 메소드가 파라미터로 객체를 받아 값을 변경하지 않도록 수정

## 테스트 결과
![스크린샷 2023-04-29 오전 11 25 59](https://user-images.githubusercontent.com/67693142/235279430-3d8ce0bf-4690-4d8f-a2c2-37520de9f6ba.png)
